### PR TITLE
Switched package to remove the REQUEST_INSTALL_PACKAGE permission (#619)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -596,8 +596,6 @@ PODS:
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/meta/type_traits
-  - app_installer (1.1.0):
-    - Flutter
   - AppAuth (1.5.0):
     - AppAuth/Core (= 1.5.0)
     - AppAuth/ExternalUserAgent (= 1.5.0)
@@ -610,18 +608,18 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.24):
     - BoringSSL-GRPC/Interface (= 0.0.24)
   - BoringSSL-GRPC/Interface (0.0.24)
-  - cloud_firestore (3.4.0):
+  - cloud_firestore (3.4.2):
     - Firebase/Firestore (= 9.3.0)
     - firebase_core
     - Flutter
-  - FBAEMKit (13.2.0):
-    - FBSDKCoreKit_Basics (= 13.2.0)
-  - FBSDKCoreKit (13.2.0):
-    - FBAEMKit (= 13.2.0)
-    - FBSDKCoreKit_Basics (= 13.2.0)
-  - FBSDKCoreKit_Basics (13.2.0)
-  - FBSDKLoginKit (13.2.0):
-    - FBSDKCoreKit (= 13.2.0)
+  - FBAEMKit (14.0.0):
+    - FBSDKCoreKit_Basics (= 14.0.0)
+  - FBSDKCoreKit (14.0.0):
+    - FBAEMKit (= 14.0.0)
+    - FBSDKCoreKit_Basics (= 14.0.0)
+  - FBSDKCoreKit_Basics (14.0.0)
+  - FBSDKLoginKit (14.0.0):
+    - FBSDKCoreKit (= 14.0.0)
   - Firebase/Analytics (9.3.0):
     - Firebase/Core
   - Firebase/Auth (9.3.0):
@@ -650,11 +648,11 @@ PODS:
   - Firebase/Storage (9.3.0):
     - Firebase/CoreOnly
     - FirebaseStorage (~> 9.3.0)
-  - firebase_analytics (9.2.1):
+  - firebase_analytics (9.3.0):
     - Firebase/Analytics (= 9.3.0)
     - firebase_core
     - Flutter
-  - firebase_auth (3.5.0):
+  - firebase_auth (3.6.1):
     - Firebase/Auth (= 9.3.0)
     - firebase_core
     - Flutter
@@ -677,11 +675,11 @@ PODS:
     - Firebase/Performance (= 9.3.0)
     - firebase_core
     - Flutter
-  - firebase_storage (10.3.3):
+  - firebase_storage (10.3.4):
     - Firebase/Storage (= 9.3.0)
     - firebase_core
     - Flutter
-  - FirebaseABTesting (9.3.0):
+  - FirebaseABTesting (9.4.0):
     - FirebaseCore (~> 9.0)
   - FirebaseAnalytics (9.3.0):
     - FirebaseAnalytics/AdIdSupport (= 9.3.0)
@@ -701,26 +699,26 @@ PODS:
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAppCheckInterop (9.3.0)
+  - FirebaseAppCheckInterop (9.4.0)
   - FirebaseAuth (9.3.0):
     - FirebaseCore (~> 9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/Environment (~> 7.7)
     - GTMSessionFetcher/Core (< 3.0, >= 1.7)
-  - FirebaseAuthInterop (9.3.0)
+  - FirebaseAuthInterop (9.4.0)
   - FirebaseCore (9.3.0):
     - FirebaseCoreDiagnostics (~> 9.0)
     - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (9.3.0):
+  - FirebaseCoreDiagnostics (9.4.0):
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCoreExtension (9.3.0):
+  - FirebaseCoreExtension (9.4.0):
     - FirebaseCore (~> 9.0)
-  - FirebaseCoreInternal (9.3.0):
+  - FirebaseCoreInternal (9.4.0):
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
   - FirebaseCrashlytics (9.3.0):
     - FirebaseCore (~> 9.0)
@@ -747,7 +745,7 @@ PODS:
     - "gRPC-C++ (~> 1.44.0)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (9.3.0):
+  - FirebaseInstallations (9.4.0):
     - FirebaseCore (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
@@ -761,7 +759,7 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (9.3.0):
+  - FirebaseRemoteConfig (9.4.0):
     - FirebaseABTesting (~> 9.0)
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
@@ -773,13 +771,12 @@ PODS:
     - FirebaseCore (~> 9.0)
     - FirebaseCoreExtension (~> 9.0)
     - FirebaseStorageInternal (~> 9.0)
-  - FirebaseStorageInternal (9.3.0):
+  - FirebaseStorageInternal (9.4.0):
     - FirebaseCore (~> 9.0)
     - GTMSessionFetcher/Core (< 3.0, >= 1.7)
   - Flutter (1.0.0)
-  - flutter_facebook_auth (4.3.0):
-    - FBSDKCoreKit (~> 13)
-    - FBSDKLoginKit (~> 13)
+  - flutter_facebook_auth (4.4.0):
+    - FBSDKLoginKit (~> 14.0.0)
     - Flutter
   - flutter_inappwebview (0.0.1):
     - Flutter
@@ -926,13 +923,14 @@ PODS:
   - sqflite (0.0.2):
     - Flutter
     - FMDB (>= 2.7.5)
+  - store_redirect (0.0.1):
+    - Flutter
   - twitter_login (0.0.1):
     - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
-  - app_installer (from `.symlinks/plugins/app_installer/ios`)
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
   - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
@@ -953,6 +951,7 @@ DEPENDENCIES:
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - store_redirect (from `.symlinks/plugins/store_redirect/ios`)
   - twitter_login (from `.symlinks/plugins/twitter_login/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -1000,8 +999,6 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
-  app_installer:
-    :path: ".symlinks/plugins/app_installer/ios"
   cloud_firestore:
     :path: ".symlinks/plugins/cloud_firestore/ios"
   firebase_analytics:
@@ -1042,6 +1039,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sign_in_with_apple/ios"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
+  store_redirect:
+    :path: ".symlinks/plugins/store_redirect/ios"
   twitter_login:
     :path: ".symlinks/plugins/twitter_login/ios"
   url_launcher_ios:
@@ -1049,43 +1048,42 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   abseil: ebe5b5529fb05d93a8bdb7951607be08b7fa71bc
-  app_installer: 4301996bd8f3c6f75776416b8885a6d92928306f
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
   BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
-  cloud_firestore: bd7f9d191e32f21b46c99884ddff554e2aab4554
-  FBAEMKit: c2b2895363b7e57192013d1dc49fdf498b28624c
-  FBSDKCoreKit: 58139803d861e72c7661dc875611a759352a55ac
-  FBSDKCoreKit_Basics: 1ffc68326a5ece051d85574f02a0adcf27c2a5f2
-  FBSDKLoginKit: 19e2a878556c2ee4f20486dc406e582783cd7578
+  cloud_firestore: d08fbf2613a90b9150619ff371a2053e89f97bbe
+  FBAEMKit: d00064597439e75885c70d9adbcb5f3e9ad84f5d
+  FBSDKCoreKit: e5d3acfffe5063a9d0b967ba2ad1f5afc460cf43
+  FBSDKCoreKit_Basics: 1ff46a12e80f0b66e6c00e1ef32d6a5b5b9008a5
+  FBSDKLoginKit: dbe86ef42ab142f3bd0f1c904a21bb33f31c5569
   Firebase: ef75abb1cdbc746d5a38f4e26c422c807b189b8c
-  firebase_analytics: 30bc6d5b0cf95ca49573741dc065e3df65160d77
-  firebase_auth: 90736e5b2600e9504c3409eea5ebcc84b9d0af7f
+  firebase_analytics: 8f772ccb3dad1e8968019a158823f99e63069d2b
+  firebase_auth: e83a8e15aeac85f05ca17c241cff4bd20e5d8c17
   firebase_core: 96214f90497b808a2cf2a24517084c5f6de37b53
   firebase_crashlytics: cdba3f556462dd5ee25cc7d28790ff2de2c0edcf
   firebase_database: 0643b8de71ac87697817b7b1317e8f70cafa7735
   firebase_dynamic_links: 0cc25cd58aa0b24acfcf10e1aaf6f32323f1c361
   firebase_performance: 82d5f536250a88ad3351583df5b1878f82cfd293
-  firebase_storage: 67c6bff2cda59f5973ea9fb2c4fca845c3055a5b
-  FirebaseABTesting: d7383da017eff5dc4fccb40987fa76271fd1cdbf
+  firebase_storage: e95ec41580e311cb30b1ed7459b9e94fb4bbe672
+  FirebaseABTesting: e59eec91fafce74a0f5261809ed0025b7e450db1
   FirebaseAnalytics: bf46f5163f44097ce2c789de0b3e6f87f1da834a
-  FirebaseAppCheckInterop: f6b9670fb1360cf12006ca426e9c3b9a35317d17
+  FirebaseAppCheckInterop: 63119cdfc94b16c3e9421513c17f597aee2ea225
   FirebaseAuth: 9ebc3577fe0acf9092df21ac314024b70aebf21e
-  FirebaseAuthInterop: 79826b4edc64e1d10135947866ad4437657e8696
+  FirebaseAuthInterop: 826d3d772b554e3675ceaab8c665008277ca9d1c
   FirebaseCore: c088995ece701a021a48a1348ea0174877de2a6a
-  FirebaseCoreDiagnostics: 060eb57cc56dfaf40b1b1b5874a5c17c41ce79f8
-  FirebaseCoreExtension: 900b065a4970c31ce8de4e966cee910188e3a07b
-  FirebaseCoreInternal: 635d1c9a612a6502b6377a0c92af83758076ffff
+  FirebaseCoreDiagnostics: aaa87098082c4d4bdd1a9557b1186d18ca85ce8c
+  FirebaseCoreExtension: 2cf8c542b54ad3c2d4b746c22e8828b670dcd9b0
+  FirebaseCoreInternal: a13302b0088fbf5f38b79b6ece49c2af7d3e05d6
   FirebaseCrashlytics: 65a5b349e664e986e6c7486b0a9b5ed8c11d0491
   FirebaseDatabase: 92350185966ddd283842aa9ca07e188691f3b8ad
   FirebaseDynamicLinks: af0acc2d1fa117a074e84a3c06a1d9f817443490
   FirebaseFirestore: 5a72aa925528f67469b16a54a6cfc369467197e4
-  FirebaseInstallations: 54b40022cb06e462740c9f2b9fbe38b5e78a825a
+  FirebaseInstallations: 61db1054e688d2bdc4e2b3f744c1b086e913b742
   FirebasePerformance: 18bb0984808ec429fae69fb5f1da4a68f57605b1
-  FirebaseRemoteConfig: 0a644c924b3339bcf3bc3ea253206f171672308e
+  FirebaseRemoteConfig: 6d9982bc64548a6e3c1b497b9fa53938ad135f2d
   FirebaseStorage: 1414d27e15fa04f6350ef6602accef0e951c8bca
-  FirebaseStorageInternal: f1a6d64cace780580d2b8ffa0a0c8cf3c376f3f8
+  FirebaseStorageInternal: 425c7dc7de44d9b7e07a9f8d6515bab0f1266b87
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  flutter_facebook_auth: a030aef1c2552fdc7cb090acc716ac836e3bb63c
+  flutter_facebook_auth: 8992ef870d441b8403a3b6b9859e7932605407cf
   flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
@@ -1109,6 +1107,7 @@ SPEC CHECKSUMS:
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
+  store_redirect: 2977747cf81689a39bd62c248c2deacb7a0d131e
   twitter_login: 2794db69b7640681171b17b3c2c84ad9dfb4a57f
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 

--- a/lib/widgets/parametric.dart
+++ b/lib/widgets/parametric.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:app_installer/app_installer.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:date_time_picker/date_time_picker.dart';
 import 'package:device_apps/device_apps.dart';
@@ -12,6 +11,7 @@ import 'package:gi_weekly_material_tracker/util.dart';
 import 'package:gi_weekly_material_tracker/widgets/drawer.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:store_redirect/store_redirect.dart';
 
 final FirebaseFirestore _db = FirebaseFirestore.instance;
 
@@ -56,7 +56,10 @@ class _ParametricPageState extends State<ParametricPage> {
                 const Spacer(
                   flex: 20,
                 ),
-                TextButton(onPressed: _resetTime, child: const Text('Reset Time')),
+                TextButton(
+                  onPressed: _resetTime,
+                  child: const Text('Reset Time'),
+                ),
                 const Spacer(),
                 TextButton(
                   onPressed: _showLastUseDialog,
@@ -170,11 +173,20 @@ class _ParametricPageState extends State<ParametricPage> {
 
           return;
         }
+      } else if (Platform.isLinux ||
+          Platform.isFuchsia ||
+          Platform.isWindows ||
+          Platform.isMacOS) {
+        // Not Supported
+        Util.showSnackbarQuick(context, "Not Supported on this Platform");
+
+        return;
       }
       // If not installed or iOS, launch app store
-      await AppInstaller.goStore(
-        androidId,
-        '1517783697',
+      debugPrint('Launching App Store');
+      await StoreRedirect.redirect(
+        androidAppId: androidId,
+        iOSAppId: '1517783697',
       );
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,13 +36,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  app_installer:
-    dependency: "direct main"
-    description:
-      name: app_installer
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   archive:
     dependency: transitive
     description:
@@ -1062,6 +1055,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
+  store_redirect:
+    dependency: "direct main"
+    description:
+      name: store_redirect
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,6 @@ dependencies:
   flutter:
     sdk: flutter
   about: ^2.1.1
-  app_installer: ^1.1.0
   cached_network_image: ^3.2.1
   cloud_firestore: ^3.4.2
   cupertino_icons: ^1.0.5 # To prevent build errors
@@ -58,6 +57,7 @@ dependencies:
   path_provider: ^2.0.11
   settings_ui: ^2.0.1
   shared_preferences: ^2.0.15
+  store_redirect: ^2.0.1
   timezone: ^0.8.0
   transparent_image: ^2.0.0
   url_launcher: ^6.1.5


### PR DESCRIPTION
Migrated from app_installer to store_redirect to remove the permission usage

We have also added checks for if the app is somehow being ran on unsupported platforms and do not attempt to open the app store for such cases

Finally we updated the Podfile to fix some issues with ios implementation and the FBSDKCoreKit (requirement of fireflutter_ui)

Took 33 minutes