### PR TITLE
ci: Replaced usage of legacy CI_PIPELINE_IID

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     env:
-      CI_PIPELINE_IID: ${{ github.run_number }}
+      GIT_RUN_NUMBER: ${{ github.run_number }}
       CI_COMMIT_REF_NAME: ${{ github.ref_name }}
       APP_BUILD_VER: web
       APP_TYPE: Web

--- a/.github/workflows/firebase-hosting-staging.yml
+++ b/.github/workflows/firebase-hosting-staging.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       APP_BUILD_VER: web
       APP_TYPE: Web
-      CI_PIPELINE_IID: ${{ github.run_number }} # Make sure when we actually build release builds it starts from 2009
+      GIT_RUN_NUMBER: ${{ github.run_number }}
       CI_COMMIT_REF_NAME: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  CI_PIPELINE_IID: ${{ github.run_number }} # Make sure when we actually build release builds it starts from 2009
+  GIT_RUN_NUMBER: ${{ github.run_number }}
   CI_COMMIT_REF_NAME: ${{ github.ref_name }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  CI_PIPELINE_IID: ${{ github.run_number }} # Make sure when we actually build release builds it starts from 2009
+  GIT_RUN_NUMBER: ${{ github.run_number }}
   CI_COMMIT_REF_NAME: ${{ github.ref_name }}
 
 jobs:
@@ -70,16 +70,13 @@ jobs:
         id: short-sha
         with:
           length: 8
-      # TODO: Add 2009 to CI_PIPELINE_IID until further notice to prevent build failure
-      # TODO: Replace CI_PIPELINE_IID with GIT_COMMIT_COUNT in the future
       - name: Pre-Setup and obtain version information
         run: |
           mkdir release
           export GIT_COMMIT_COUNT="$(git rev-list --count HEAD)"
-          export CI_PIPELINE_IID=$(($CI_PIPELINE_IID + 2009))
           echo $GIT_COMMIT_COUNT
           echo $GIT_COMMIT_SHORT_SHA
-          echo $CI_PIPELINE_IID
+          echo $GIT_RUN_NUMBER
           chmod +x ./ciscripts/get_version.sh
           ./ciscripts/get_version.sh
         env:
@@ -163,19 +160,16 @@ jobs:
         id: short-sha
         with:
           length: 8
-      # TODO: Add 2009 to CI_PIPELINE_IID until further notice to prevent build failure
-      # TODO: Replace CI_PIPELINE_IID with GIT_COMMIT_COUNT in the future
       - name: Pre-Setup and obtain version information
         id: versioninfo
         run: |
           export GIT_COMMIT_COUNT="$(git rev-list --count HEAD)"
-          export CI_PIPELINE_IID=$(($CI_PIPELINE_IID + 2009))
           echo $GIT_COMMIT_COUNT
           echo $GIT_COMMIT_SHORT_SHA
-          echo $CI_PIPELINE_IID
+          echo $GIT_RUN_NUMBER
           chmod +x ./ciscripts/get_version.sh
           ./ciscripts/get_version.sh
-          echo "pipeline_id=$CI_PIPELINE_IID" >> $GITHUB_OUTPUT
+          echo "pipeline_id=$GIT_COMMIT_COUNT" >> $GITHUB_OUTPUT
         env:
           CI_COMMIT_SHORT_SHA: ${{ steps.short-sha.outputs.sha }}
       - name: Build Android AppBundle
@@ -298,7 +292,7 @@ jobs:
     environment: GPlay-Alpha-Android
     name: Deploy to Google Play Alpha # From "Deploy to Google Play Alpha" in GitLab CI
     env:
-      CI_PIPELINE_IID: ${{ needs.releaseaab.outputs.relid }}
+      GIT_COMMIT_COUNT: ${{ needs.releaseaab.outputs.relid }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -311,14 +305,14 @@ jobs:
         working-directory: android
         run: |
           fastlane run download_from_play_store track:"alpha"
-          cp ../LATEST fastlane/metadata/android/en-US/changelogs/$CI_PIPELINE_IID.txt
+          cp ../LATEST fastlane/metadata/android/en-US/changelogs/$GIT_COMMIT_COUNT.txt
           cp ../appbundle-signed.aab .
           cp ../VERSION .
       - name: Deploying to Alpha Track on Google Play
         working-directory: android
         run: |
           APP_VERSION=$(cat ./VERSION)
-          fastlane supply --aab appbundle-signed.aab --track alpha --skip_upload_images true --skip_upload_screenshots true --version_name "$CI_PIPELINE_IID ($APP_VERSION)"
+          fastlane supply --aab appbundle-signed.aab --track alpha --skip_upload_images true --skip_upload_screenshots true --version_name "$GIT_COMMIT_COUNT ($APP_VERSION)"
   generaterelease:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')

--- a/ciscripts/get_version.sh
+++ b/ciscripts/get_version.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 echo "Updating versioning number for flutter app"
 APP_VERSION=$(cat ./VERSION)
-sed -i.bak "s|version: 1.0.0+1|version: $APP_VERSION+$APP_BUILD_VER.b$CI_PIPELINE_IID|g" pubspec.yaml
+sed -i.bak "s|version: 1.0.0+1|version: $APP_VERSION+$APP_BUILD_VER.b$GIT_COMMIT_COUNT|g" pubspec.yaml
 rm pubspec.yaml.bak
 builddate="$(date +"%A, %d %B %Y %T %Z")"
-echo "Version $APP_VERSION ($APP_BUILD_VER.b$GIT_COMMIT_COUNT) Commit SHA #$CI_COMMIT_SHORT_SHA $APP_TYPE Application build on $builddate on branch $CI_COMMIT_REF_NAME with Pipeline $CI_PIPELINE_IID"
+echo "Version $APP_VERSION ($APP_BUILD_VER.b$GIT_COMMIT_COUNT) Commit SHA #$CI_COMMIT_SHORT_SHA $APP_TYPE Application build on $builddate on branch $CI_COMMIT_REF_NAME with Pipeline $GIT_RUN_NUMBER"


### PR DESCRIPTION
That env variable was a legacy variable from the GitLab era and has since been properly replaced and retired