### PR TITLE
fix: Upgrade Notification Library to remove permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,10 @@
         <package android:name="com.miHoYo.GenshinImpact" />
         <package android:name="com.mihoyo.hoyolab" />
     </queries>
+    <!-- For Notifications -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
    <application
         android:label="GI Weekly Material Tracker"
         android:usesCleartextTraffic="true"
@@ -34,5 +38,17 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+       <!-- For Notifications -->
+       <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+       <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+           <intent-filter>
+               <action android:name="android.intent.action.BOOT_COMPLETED"/>
+               <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+               <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+               <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+           </intent-filter>
+       </receiver>
+       <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver" />
     </application>
 </manifest>

--- a/lib/widgets/appsettings.dart
+++ b/lib/widgets/appsettings.dart
@@ -139,7 +139,7 @@ class SettingsPageState extends State<SettingsPage> {
         if (!result) {
           Util.showSnackbarQuick(
             context,
-            'Failed to schedule reminder. Make sure permission to post notification is enabled',
+            'Failed to schedule reminder. Make sure permission to post notification and exact alarm is enabled',
           );
         } else {
           Util.showSnackbarQuick(
@@ -165,7 +165,7 @@ class SettingsPageState extends State<SettingsPage> {
         if (!result) {
           Util.showSnackbarQuick(
             context,
-            'Failed to schedule reminder. Make sure permission to post notification is enabled',
+            'Failed to schedule reminder. Make sure permission to post notification and exact alarm is enabled',
           );
         } else {
           Util.showSnackbarQuick(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -611,10 +611,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "53c332ecee8e4d723269c1c2d0cdf7cbbff0a66cc0554d230a6f38cae81760d1"
+      sha256: "55b9b229307a10974b26296ff29f2e132256ba4bd74266939118eaefa941cb00"
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.4"
+    version: "16.3.3"
   flutter_local_notifications_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   flutter_countdown_timer: ^4.1.0
   flutter_file_dialog: ^3.0.2
   flutter_inappwebview: ^6.0.0-beta.25
-  flutter_local_notifications: ^14.1.4
+  flutter_local_notifications: ^16.1.0
   flutter_rating_bar: ^4.0.1
   flutter_signin_button: ^2.0.0
   flutter_svg: ^2.0.8


### PR DESCRIPTION
As per Google Play Policy, we need to remove USE_FULL_SCREEN_INTENT permission by 31 May 2024. Upon investigation, this permission is set by the flutter_local_notifications library. We update the library and reimplemented checks ourselves to ensure that it is compliant with Google Play policy