### PR TITLE
ci: Switched to Node.JS 24 from Node.JS 20

### DIFF
--- a/.github/workflows/firebase-update.yml
+++ b/.github/workflows/firebase-update.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Use Node.JS 20
+      - name: Use Node.JS 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: util/package-lock.json
       - run: npm ci --ignore-scripts
@@ -166,10 +166,10 @@ jobs:
     if: needs.changedfiles.outputs.rtdbbanner
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Use Node.JS 20
+      - name: Use Node.JS 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: util/package-lock.json
       - name: Extract Service Account Key
@@ -194,10 +194,10 @@ jobs:
     if: needs.changedfiles.outputs.fspj
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Use Node.JS 20
+      - name: Use Node.JS 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: util/package-lock.json
       - name: Extract Service Account Key
@@ -300,10 +300,10 @@ jobs:
     if: needs.changedfiles.outputs.fbcf
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Use Node.JS 20
+      - name: Use Node.JS 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: firebase/functions/package-lock.json
       - name: Install Dependencies
@@ -323,10 +323,10 @@ jobs:
     if: needs.changedfiles.outputs.fstj
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Use Node.JS 20
+      - name: Use Node.JS 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: util/package-lock.json
       - name: Extract Service Account Key


### PR DESCRIPTION
Node.JS 20 had EOL'd in April 26. Time to upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js runtime used by automated deployment and data-update workflows to Node.js 24.x.
  * No user-facing functionality changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->